### PR TITLE
Test with Java 21 and require Java 11 and Jenkins 2.361.4 or newer

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  platforms: ['linux'],
-)
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.47</version>
+    <version>4.55</version>
     <relativePath />
   </parent>
   <artifactId>handy-uri-templates-2-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <revision>2.1.8</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.55</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
   <artifactId>handy-uri-templates-2-api</artifactId>


### PR DESCRIPTION
## Test with Java 21 and require Java 11 and Jenkins 2.361.4 or newer

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Supersedes pull request:

* #27
* #26

### Testing done

Confirmed tests pass on Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
